### PR TITLE
DataLabel 'rotation' and 'allowOverlap' properties added

### DIFF
--- a/AAChartKitLib/AAChartConfiger/AAChartModel.h
+++ b/AAChartKitLib/AAChartConfiger/AAChartModel.h
@@ -156,12 +156,10 @@ AAPropStatementAndFuncStatement(assign, AAChartModel, BOOL,       dataLabelEnabl
 AAPropStatementAndFuncStatement(copy,   AAChartModel, NSString *, dataLabelFontColor);//Datalabel font color
 AAPropStatementAndFuncStatement(strong, AAChartModel, NSNumber *, dataLabelFontSize);//Datalabel font size
 AAPropStatementAndFuncStatement(copy,   AAChartModel, NSString *, dataLabelFontWeight);//Datalabel font weight
-//******
 AAPropStatementAndFuncStatement(copy,   AAChartModel, NSNumber *, dataLabelRotation);//Datalabel rotation in degrees 
 AAPropStatementAndFuncStatement(assign, AAChartModel, BOOL,       dataLabelAllowOverlap);//Datalabel allow overlapping
 //(Note: if rotation <> 0, 'dataLabelAllowOverlap' will not work - this is a bug in HighCharts (https://github.com/highcharts/highcharts/issues/7362)
 //******
-
 
 AAPropStatementAndFuncStatement(assign, AAChartModel, BOOL,       xAxisLabelsEnabled);//x 轴是否显示数据
 AAPropStatementAndFuncStatement(copy,   AAChartModel, NSNumber *, xAxisLabelsFontSize);//xAxis font size

--- a/AAChartKitLib/AAChartConfiger/AAChartModel.h
+++ b/AAChartKitLib/AAChartConfiger/AAChartModel.h
@@ -156,6 +156,12 @@ AAPropStatementAndFuncStatement(assign, AAChartModel, BOOL,       dataLabelEnabl
 AAPropStatementAndFuncStatement(copy,   AAChartModel, NSString *, dataLabelFontColor);//Datalabel font color
 AAPropStatementAndFuncStatement(strong, AAChartModel, NSNumber *, dataLabelFontSize);//Datalabel font size
 AAPropStatementAndFuncStatement(copy,   AAChartModel, NSString *, dataLabelFontWeight);//Datalabel font weight
+//******
+AAPropStatementAndFuncStatement(copy,   AAChartModel, NSNumber *, dataLabelRotation);//Datalabel rotation in degrees 
+AAPropStatementAndFuncStatement(assign, AAChartModel, BOOL,       dataLabelAllowOverlap);//Datalabel allow overlapping
+//(Note: if rotation <> 0, 'dataLabelAllowOverlap' will not work - this is a bug in HighCharts (https://github.com/highcharts/highcharts/issues/7362)
+//******
+
 
 AAPropStatementAndFuncStatement(assign, AAChartModel, BOOL,       xAxisLabelsEnabled);//x 轴是否显示数据
 AAPropStatementAndFuncStatement(copy,   AAChartModel, NSNumber *, xAxisLabelsFontSize);//xAxis font size

--- a/AAChartKitLib/AAChartConfiger/AAChartModel.m
+++ b/AAChartKitLib/AAChartConfiger/AAChartModel.m
@@ -151,7 +151,6 @@ AAPropSetFuncImplementation(AAChartModel, BOOL,       dataLabelEnabled);//是否
 AAPropSetFuncImplementation(AAChartModel, NSString *, dataLabelFontColor);//Datalabel font color
 AAPropSetFuncImplementation(AAChartModel, NSNumber *, dataLabelFontSize);//Datalabel font size
 AAPropSetFuncImplementation(AAChartModel, NSString *, dataLabelFontWeight);//Datalabel font weight
-//******
 AAPropSetFuncImplementation(AAChartModel, NSNumber *, dataLabelRotation);//Datalabel rotation in degrees 
 AAPropSetFuncImplementation(AAChartModel, BOOL,       dataLabelAllowOverlap);//Datalabel allow overlapping
 //(Note: if rotation <> 0, 'dataLabelAllowOverlap' will not work - this is a bug in HighCharts (https://github.com/highcharts/highcharts/issues/7362)

--- a/AAChartKitLib/AAChartConfiger/AAChartModel.m
+++ b/AAChartKitLib/AAChartConfiger/AAChartModel.m
@@ -151,6 +151,11 @@ AAPropSetFuncImplementation(AAChartModel, BOOL,       dataLabelEnabled);//是否
 AAPropSetFuncImplementation(AAChartModel, NSString *, dataLabelFontColor);//Datalabel font color
 AAPropSetFuncImplementation(AAChartModel, NSNumber *, dataLabelFontSize);//Datalabel font size
 AAPropSetFuncImplementation(AAChartModel, NSString *, dataLabelFontWeight);//Datalabel font weight
+//******
+AAPropSetFuncImplementation(AAChartModel, NSNumber *, dataLabelRotation);//Datalabel rotation in degrees 
+AAPropSetFuncImplementation(AAChartModel, BOOL,       dataLabelAllowOverlap);//Datalabel allow overlapping
+//(Note: if rotation <> 0, 'dataLabelAllowOverlap' will not work - this is a bug in HighCharts (https://github.com/highcharts/highcharts/issues/7362)
+//******
 
 AAPropSetFuncImplementation(AAChartModel, BOOL,       xAxisLabelsEnabled);//x 轴是否显示数据
 AAPropSetFuncImplementation(AAChartModel, NSNumber *, xAxisLabelsFontSize);//x-axis labels font size

--- a/AAChartKitLib/AAChartConfiger/AAOptionsConstructor.m
+++ b/AAChartKitLib/AAChartConfiger/AAOptionsConstructor.m
@@ -231,6 +231,9 @@
                                             .colorSet(aaChartModel.dataLabelFontColor)
                                             .fontSizeSet(AAFontSizeFormat(aaChartModel.dataLabelFontSize))
                                             .fontWeightSet(aaChartModel.dataLabelFontWeight))
+                                            .rotationSet(aaChartModel.dataLabelRotation)
+                                            .allowOverlapSet(aaChartModel.dataLabelAllowOverlap)
+                                            //(Note: if rotation <> 0, 'dataLabelAllowOverlap' will not work - this is a bug in HighCharts (https://github.com/highcharts/highcharts/issues/7362)
                                   );
     
     if ([chartType isEqualToString:AAChartTypeColumn]) {

--- a/AAChartKitLib/AAOptionsModel/AADataLabels.h
+++ b/AAChartKitLib/AAOptionsModel/AADataLabels.h
@@ -36,8 +36,10 @@
 
 @interface AADataLabels : NSObject
 
-AAPropStatementAndFuncStatement(assign, AADataLabels, BOOL,       enabled);
+AAPropStatementAndFuncStatement(assign, AADataLabels, BOOL      , enabled);
 AAPropStatementAndFuncStatement(strong, AADataLabels, AAStyle  *, style);
 AAPropStatementAndFuncStatement(copy,   AADataLabels, NSString *, format);
+AAPropStatementAndFuncStatement(copy,   AADataLabels, NSNumber *, rotation);
+AAPropStatementAndFuncStatement(assign, AADataLabels, BOOL      , allowOverlap);
 
 @end

--- a/AAChartKitLib/AAOptionsModel/AADataLabels.m
+++ b/AAChartKitLib/AAOptionsModel/AADataLabels.m
@@ -47,8 +47,10 @@
 //    return self;
 //}
 
-AAPropSetFuncImplementation(AADataLabels, BOOL,       enabled);
+AAPropSetFuncImplementation(AADataLabels, BOOL      , enabled);
 AAPropSetFuncImplementation(AADataLabels, AAStyle  *, style);
 AAPropSetFuncImplementation(AADataLabels, NSString *, format);
+AAPropSetFuncImplementation(AADataLabels, NSNumber *, rotation);
+AAPropSetFuncImplementation(AADataLabels, BOOL      , allowOverlap);
 
 @end


### PR DESCRIPTION
DataLabel 'rotation' and 'allowOverlap' properties added. Please note: if rotation <> 0, 'dataLabelAllowOverlap' will not work - this is a bug in HighCharts (https://github.com/highcharts/highcharts/issues/7362)