### PR TITLE
'additionalOptions' property added to AAChartModel

### DIFF
--- a/AAChartKitDemo/ChartsDemo/SecondViewController.m
+++ b/AAChartKitDemo/ChartsDemo/SecondViewController.m
@@ -182,6 +182,18 @@
         _aaChartModel.categories = @[@"Java", @"Swift", @"Python", @"Ruby", @"PHP", @"Go", @"C", @"C#", @"C++", @"Perl", @"R", @"MATLAB", @"SQL"];//设置 X 轴坐标内容
         _aaChartModel.animationType = AAChartAnimationBounce;//图形的渲染动画为弹性动画
         _aaChartModel.animationDuration = @1200;//图形渲染动画时长为1200毫秒
+          
+        //*****************************   
+        //Test for additionalOptions
+        NSDictionary *additionalOptions = @{
+                                                @"yAxis":@{
+                                                        @"alternateGridColor":@"#5b3796"
+                                                        }
+                                                };
+        
+        _aaChartModel.additionalOptionsSet(additionalOptions);
+        //*****************************
+     
        // _aaChartModel.xAxisTickInterval = @3;//设置 X轴坐标点的间隔数,默认是1(手机端的屏幕较为狭窄, 如果X轴坐标点过多,文字过于密集的时候可以设置此属性值,用户的密集恐惧症将得到有效治疗😝)
     } else if (self.chartType == SecondeViewControllerChartTypeArea
                || self.chartType == SecondeViewControllerChartTypeAreaspline) {

--- a/AAChartKitLib/AAChartConfiger/AAChartModel.h
+++ b/AAChartKitLib/AAChartConfiger/AAChartModel.h
@@ -207,4 +207,7 @@ AAPropStatementAndFuncStatement(strong, AAChartModel, NSNumber *, yAxisMin);//y 
 AAPropStatementAndFuncStatement(strong, AAChartModel, NSArray  *, yAxisTickPositions);//自定义 y 轴坐标（如：[@(0), @(25), @(50), @(75) , (100)]）
 AAPropStatementAndFuncStatement(copy,   AAChartModel, NSString *, zoomResetButtonText); //String to display in 'zoom reset button"
 
+//Additional options as a dictionary with JavaScript properties - note: if set, equal properties from the chartmodel will be overwritten!
+AAPropStatementAndFuncStatement(strong, AAChartModel, NSDictionary  *, additionalOptions);
+
 @end

--- a/AAChartKitLib/AAChartConfiger/AAChartModel.m
+++ b/AAChartKitLib/AAChartConfiger/AAChartModel.m
@@ -203,4 +203,7 @@ AAPropSetFuncImplementation(AAChartModel, NSNumber *, yAxisMin);//y 轴最小值
 AAPropSetFuncImplementation(AAChartModel, NSArray  *, yAxisTickPositions);//自定义 y 轴坐标（如：[@(0), @(25), @(50), @(75) , (100)]）
 AAPropSetFuncImplementation(AAChartModel, NSString *, zoomResetButtonText); //String to display in 'zoom reset button"
 
+//Additional options as a dictionary with JavaScript properties - note: if set, equal properties from the chartmodel will be overwritten!
+AAPropSetFuncImplementation(AAChartModel, NSDictionary  *, additionalOptions);
+
 @end

--- a/AAChartKitLib/AAChartConfiger/AAChartView.m
+++ b/AAChartKitLib/AAChartConfiger/AAChartView.m
@@ -54,6 +54,7 @@
     UIWebView *_uiWebView;
     WKWebView *_wkWebView;
     NSString  *_optionJson;
+    NSDictionary *_dictAdditionalOptions;
 }
 
 @end
@@ -140,6 +141,44 @@
         options.chart.backgroundColor = @"rgba(0,0,0,0)";
     }
     _optionJson = [AAJsonConverter getPureOptionsString:options];
+ 
+     //Check if _dictAdditionalOptions (which is equal to chartModel.additionalOptions) is not nil
+    if (_dictAdditionalOptions)
+    {
+        
+        //Convert _optionJson to NSDictionary
+        NSData *data = [_optionJson dataUsingEncoding:NSUTF8StringEncoding];
+        NSError *error;
+        NSMutableDictionary *jsonDict = [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+        
+        //Create a temporay copy of the dictionary which we can modify while enumerating the original
+        NSMutableDictionary *jsonDictTemp = [jsonDict mutableCopy];
+        
+        //Enumerate the dictionary
+        for (id key in _dictAdditionalOptions)
+        {
+            
+            if (![[jsonDict allKeys] containsObject:key]) // If key does not already exist options dictionary, copy it from the _dictAdditionalOptions dictionary
+            {
+                [jsonDictTemp setObject:[_dictAdditionalOptions objectForKey:key] forKey:key];
+            }
+            else // If key does already exist options dictionary, delete it and set the new one from the _dictAdditionalOptions dictionary
+            {
+                [jsonDictTemp removeObjectForKey:key];
+                [jsonDictTemp setObject:[_dictAdditionalOptions objectForKey:key] forKey:key];
+            }
+        }
+        
+        //Now, convert the dictionary back to a JSON string
+        NSError * err;
+        NSData * jsonData = [NSJSONSerialization dataWithJSONObject:jsonDictTemp options:0 error:&err];
+        NSString * myString = [[[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding] substringFromIndex:1];
+        
+        //Done: add a leading { to the new _optionJson
+        _optionJson=[NSString stringWithFormat:@"%@%@",@"{", myString];
+        
+    }
+ 
 }
 
 - (NSString *)configTheJavaScriptString {
@@ -157,11 +196,13 @@
 //
 - (void)aa_drawChartWithChartModel:(AAChartModel *)chartModel {
     AAOptions *options = [AAOptionsConstructor configureChartOptionsWithAAChartModel:chartModel];
+    _dictAdditionalOptions=chartModel.additionalOptions;
     [self aa_drawChartWithOptions:options];
 }
 
 - (void)aa_refreshChartWithChartModel:(AAChartModel *)chartModel {
      AAOptions *options = [AAOptionsConstructor configureChartOptionsWithAAChartModel:chartModel];
+     _dictAdditionalOptions=chartModel.additionalOptions;
     [self aa_refreshChartWithOptions:options];
 }
 


### PR DESCRIPTION
This new property allows it to extend the AAChartModel with a dicitionary of JavaScript options. This is extremely helpful for properties which are currently not supported by the AAChartModel.

```
        //Test for additionalOptions
        NSDictionary *additionalOptions = @{
                                                @"yAxis":@{
                                                        @"alternateGridColor":@"#5b3796"
                                                        }
                                                };
        
        _aaChartModel.additionalOptionsSet(additionalOptions);
```

Please note that options from the AAChartModel will be overwritten if they exist (and if set) in the AAChartModel. That means that the options contained in the 'additionalOptions' dictionary have priority.

See example in demo (SecondViewController.m), where we set the 'alternateGridColor' of the yAxis for the column or bar chart sample.