### PR TITLE
Crosshair disabled by default, conditional checks

### DIFF
--- a/AAChartKitLib/AAChartConfiger/AAChartModel.m
+++ b/AAChartKitLib/AAChartConfiger/AAChartModel.m
@@ -132,10 +132,10 @@ AACrosshairDashStyleType const AACrosshairDashStyleTypeLongDashDotDot = @"LongDa
         self.yAxisLabelsFontWeight  = AAChartFontWeightTypeThin;//细体字
         self.yAxisAlternateGridColor= @"#ffffff";//backcolor of every other grid line area
         
-        self.xAxisCrosshairWidth    = @2;
+        self.xAxisCrosshairWidth    = @0;//Zero width to disable crosshair by default
         self.xAxisCrosshairColor    = @"#00bfff";
         self.xAxisCrosshairDashStyleType = AACrosshairDashStyleTypeLongDashDot;
-        self.yAxisCrosshairWidth    = @2;
+        self.yAxisCrosshairWidth    = @0;//Zero width to disable crosshair by default
         self.yAxisCrosshairColor    = @"#00bfff";
         self.yAxisCrosshairDashStyleType = AACrosshairDashStyleTypeLongDashDot;
         

--- a/AAChartKitLib/AAChartConfiger/AAOptionsConstructor.m
+++ b/AAChartKitLib/AAChartConfiger/AAOptionsConstructor.m
@@ -143,12 +143,16 @@
     .gridLineWidthSet(aaChartModel.xAxisGridLineWidth)//x轴网格线宽度
     .categoriesSet(aaChartModel.categories)
     .visibleSet(aaChartModel.xAxisVisible)//x轴是否可见
-    .crosshairSet(AAObject(AACrosshair)
+    .tickIntervalSet(aaChartModel.xAxisTickInterval);//x轴坐标点间隔数
+    
+    if ([aaChartModel.xAxisCrosshairWidth floatValue]>0)
+    {
+    aaXAxis.crosshairSet(AAObject(AACrosshair)
                   .widthSet(aaChartModel.xAxisCrosshairWidth)
                   .colorSet(aaChartModel.xAxisCrosshairColor)
                   .dashStyleSet(aaChartModel.xAxisCrosshairDashStyleType)
-                  )
-    .tickIntervalSet(aaChartModel.xAxisTickInterval);//x轴坐标点间隔数
+                  );
+    }
     
     aaYAxis.labelsSet(AAObject(AALabels)
                       .enabledSet(aaChartModel.yAxisLabelsEnabled)//设置 y 轴是否显示数字
@@ -171,11 +175,16 @@
     .lineWidthSet(@0)//设置 y轴轴线的宽度为0,即是隐藏 y轴轴线
     .visibleSet(aaChartModel.yAxisVisible)
     .tickIntervalSet(aaChartModel.yAxisTickInterval)
-    .crosshairSet(AAObject(AACrosshair)
+     
+    if ([aaChartModel.yAxisCrosshairWidth floatValue]>0)
+    {
+    aaYAxis.crosshairSet(AAObject(AACrosshair)
                   .widthSet(aaChartModel.yAxisCrosshairWidth)
                   .colorSet(aaChartModel.yAxisCrosshairColor)
                   .dashStyleSet(aaChartModel.yAxisCrosshairDashStyleType)
                   );
+    }
+ 
 }
 
 + (void)configureTheStyleOfConnectNodeWithChartModel:(AAChartModel *)aaChartModel plotOptions:(AAPlotOptions *)aaPlotOptions {


### PR DESCRIPTION
Only show a crosshair if crosshair width > 0. This applies to both xAxis and yAxis crosshairs. This fixes https://github.com/AAChartModel/AAChartKit/issues/195