### PR TITLE
修复html在tableview中超过状态栏位置自动偏移情况

### DIFF
--- a/AAChartKitLib/AAJSFiles.bundle/AAChartView.html
+++ b/AAChartKitLib/AAJSFiles.bundle/AAChartView.html
@@ -30,7 +30,7 @@
 <html>
     <head>
         <meta charset="UTF-8" />
-        <meta name="viewport" content="width = device-width, initial-scale = 1.0, minimum-scale = 1.0, maximum-scale = 3.0,user-scalable = no">
+        <meta name="viewport" content="width = device-width, initial-scale = 1.0, minimum-scale = 1.0, maximum-scale = 3.0,user-scalable = no,viewport-fit = cover">
         <script src="AAHighchartsLib.js">
         </script>
         <script src="AAHighchartsMore.js">


### PR DESCRIPTION
适配ios11修复html在tableview中超过状态栏位置自动偏移情况。
当控件父视图滑动超过状态栏，会影响web的尺寸。
个人认为作为组件frame应该为强制性。
[viewport-fit相关说明](https://www.jianshu.com/p/1bc606b56ae4)
