### PR TITLE
Add contentInsetAdjustmentBehavior for AAChartView.

### DIFF
--- a/AAChartKitLib/AAChartConfiger/AAChartView.h
+++ b/AAChartKitLib/AAChartConfiger/AAChartView.h
@@ -45,6 +45,11 @@
 
 @property (nonatomic, weak)   id<AAChartViewDidFinishLoadDelegate> delegate;
 
+/* Configure the behavior of adjustedContentInset.
+ Default is UIScrollViewContentInsetAdjustmentAutomatic.
+ */
+@property(nonatomic) UIScrollViewContentInsetAdjustmentBehavior contentInsetAdjustmentBehavior API_AVAILABLE(ios(11.0),tvos(11.0));
+
 /**
  Set the chart view can scroll or not
  */

--- a/AAChartKitLib/AAChartConfiger/AAChartView.m
+++ b/AAChartKitLib/AAChartConfiger/AAChartView.m
@@ -270,6 +270,15 @@
 
 #pragma mark -- setter method
 
+- (void)setContentInsetAdjustmentBehavior:(UIScrollViewContentInsetAdjustmentBehavior)contentInsetAdjustmentBehavior {
+    _contentInsetAdjustmentBehavior = contentInsetAdjustmentBehavior;
+    if (AASYSTEM_VERSION >= 9.0) {
+        _wkWebView.scrollView.contentInsetAdjustmentBehavior = _contentInsetAdjustmentBehavior;
+    } else {
+        _uiWebView.scrollView.contentInsetAdjustmentBehavior = _contentInsetAdjustmentBehavior;
+    }
+}
+
 - (void)setScrollEnabled:(BOOL)scrollEnabled {
     _scrollEnabled = scrollEnabled;
     if (AASYSTEM_VERSION >= 9.0) {


### PR DESCRIPTION
在`iOS11`以后，当我在`TableViewCell`上使用`AAChartView`时，滚动的时候`AAChartVIew`显示不正确。我发现是 `AAChartVIew` 里面的`webview.scrollView` 的 `contentInsetAdjustmentBehavior` 影响的，我的`tableivew`做了如下设置：
``` OC
if ([self.tableView respondsToSelector:@selector(setContentInsetAdjustmentBehavior:)]) {
            self.tableView.contentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentNever;
        }
```
但是`AAChartVIew` 的`webview.scrollView`的`contentInsetAdjustmentBehavior`是默认的,即
```UIScrollViewContentInsetAdjustmentAutomatic```。

这时候我无法在外面容易的设置`webView.scrollView.contentInsetAdjustmentBehavior`所以我觉得应该加一个`contentInsetAdjustmentBehavior`属性用来设置`webView.scrollView`的`contentInsetAdjustmentBehavior`。