### PR TITLE
🚀  增加fastlane脚本，快速发布新版本到cocoapod

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,9 +63,11 @@ lane :release_pod do |options|
   pod_lib_lint(allow_warnings: true)
   if target_repo
     pod_push(path: spec_path, repo: target_repo, allow_warnings: true)
+    # 发布成功
     UI.message("Release lib #{target_project} new version #{target_version} to #{target_repo}  Successfully! 🎉 ")
   else
     pod_push(path: spec_path, allow_warnings: true)
+    # 发布成功
     UI.message("Release lib #{target_project} new version #{target_version} to CocoaPods/Specs Successfully! 🎉 ")
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,71 @@
+desc '发布pod新版本'
+lane :release_pod do |options|
+  # 存放私有podspec的仓库名
+  target_repo    = options[:repo]
+
+  # 需要更新的项目名称
+  target_project = options[:project]
+
+  # 需要更新的 pod 版本
+  target_version = options[:version]
+
+  # 本次更新的提交信息
+  target_desc    = options[:desc]
+
+  # podspec 的路径
+  spec_path      = "#{target_project}.podspec"
+
+  # 参数判断
+  if target_project.nil? || target_project.empty? || target_version.nil? || target_version.empty?
+    UI.message("❌ 项目名称、更新的pod版本必须填写")
+    exit
+  end
+
+  # 开始发布
+  UI.message("👉 开始发布 #{target_project} 新的版本： #{target_version}")
+
+  # 确认是master分支
+  ensure_git_branch
+  # 修改 spec 为即将发布的版本
+  version_bump_podspec(path: spec_path, version_number: target_version)
+  # commit 代码
+  git_add(path: '.')
+  begin
+    if target_desc.nil? || target_desc.empty?
+      git_commit(path: '.', message: "release #{target_version}")
+    else
+      git_commit(path: '.', message: target_desc)
+    end
+  rescue
+    error_message = "#{$!}"
+    UI.message("❌ git commit 报错:#{error_message}")
+    unless error_message.include?("nothing to commit, working directory clean")
+      exit
+    end
+    UI.message("本地代码已经commit, 跳过此次commit")
+  end
+  # 拉取最新代码
+  # git_pull_allow_unrelated_histories
+  git_pull(rebase: true) # use --rebase with pull
+  # 提交代码到远端仓库
+  push_to_git_remote
+  # 判断 tag 是否存在
+  if git_tag_exists(tag: target_version)
+      UI.message("Tag #{target_version} 已经存在, 正在删除旧的tag 💥")
+      # tag 已存在，则删除旧的tag
+      remove_git_tag(tag: target_version)
+  end
+  # 添加新的 tag
+  add_git_tag(tag: target_version)
+  # 提交新的 tag 到远端仓库
+  push_git_tags
+  # 验证此次更新是否合法
+  pod_lib_lint(allow_warnings: true)
+  if target_repo
+    pod_push(path: spec_path, repo: target_repo, allow_warnings: true)
+    UI.message("Release lib #{target_project} new version #{target_version} to #{target_repo}  Successfully! 🎉 ")
+  else
+    pod_push(path: spec_path, allow_warnings: true)
+    UI.message("Release lib #{target_project} new version #{target_version} to CocoaPods/Specs Successfully! 🎉 ")
+  end
+end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,0 +1,8 @@
+
+# 发布pod新版本
+
+```
+fastlane release_pod version:'6.5.0'  project:'AAChartKit'  desc:'✨ 发布版本6.5.0'
+```
+
+

--- a/fastlane/actions/git_pull_allow_unrelated_histories.rb
+++ b/fastlane/actions/git_pull_allow_unrelated_histories.rb
@@ -1,0 +1,50 @@
+module Fastlane
+  module Actions
+    class GitPullAllowUnrelatedHistoriesAction < Action
+      def self.run(params)
+        commands = []
+
+        unless params[:only_tags]
+          command = "git pull origin master --allow-unrelated-histories"
+          command << " --rebase" if params[:rebase]
+          # commands += ["#{command} &&"]
+        end
+
+        # commands += ["git fetch --tags"]
+
+        Actions.sh(commands.join(' '))
+      end
+
+      def self.description
+        "拉取最新代码，允许合并不相关的历史内容"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :only_tags,
+                                       description: "只需拉取tag，而不是从远程将新提交带到当前分支",
+                                       type: Boolean,
+                                       optional: true,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :rebase,
+                                       description: "在远程分支之上使用rebase而不是merge",
+                                       type: Boolean,
+                                       optional: true,
+                                       default_value: false)
+        ]
+      end
+
+      def self.authors
+        ["vin"]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.category
+        :source_control
+      end
+    end
+  end
+end

--- a/fastlane/actions/remove_git_tag.rb
+++ b/fastlane/actions/remove_git_tag.rb
@@ -1,0 +1,93 @@
+module Fastlane
+  module Actions
+    class RemoveGitTagAction < Action
+      def self.run(params)
+        command = []
+
+        target_tag = params[:tag]
+        remove_local = params[:remove_local]
+        remove_remote = params[:remove_remote]
+
+        command << "git tag -d #{target_tag}" if remove_local
+        command << "git push origin :#{target_tag}" if remove_remote
+
+        if command.empty?
+          UI.message('👉 删除旧的Git tag 必须设置新的tag以及要删除的旧tag')
+        else
+          result = command.join(' & ')
+          Actions.sh(result)
+          UI.message('删除tag成功 🎉')
+        end
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "删除已经存在的Git tag"
+      end
+
+      def self.details
+        "删除一个远端仓库或本地仓库中存在的Git tag"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :tag,
+                                       description: '要删除的tag',
+                                       is_string: true,
+                                       optional: false),
+          FastlaneCore::ConfigItem.new(key: :remove_local,
+                                       description: '删除本地仓库tag',
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :remove_remote,
+                                       description: '删除远端仓库tag',
+                                       is_string: false,
+                                       optional: true,
+                                       default_value: true)
+        ]
+      end
+
+      def self.output
+      end
+
+      def self.return_value
+        # If your method provides a return value, you can describe here what it does
+        nil
+      end
+
+      def self.authors
+        ["vin"]
+      end
+
+      def self.is_supported?(platform)
+        # you can do things like
+        #
+        #  true
+        #
+        #  platform == :ios
+        #
+        #  [:ios, :mac].include?(platform)
+        #
+
+        [:ios, :mac].include?(platform)
+      end
+
+      def self.example_code
+        [
+          'remove_git_tag(tag: "0.1.0") # 删除本地仓库tag和远端仓库tag',
+          'remove_git_tag(tag: "0.1.0", remove_local: false) # 只远端仓库tag',
+          'remove_git_tag(tag: "0.1.0", remove_remote: false) # 只删除本地仓库tag'
+        ]
+      end
+
+      def self.category
+        :source_control
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
pod引入的时候指定Git地址有很多局限性，每次还是发布新版本到cocoapod比较好，所以就增加了fastlane脚本，一键发布